### PR TITLE
Implement helpers for using alloca-based stack arrays

### DIFF
--- a/ranges/stackarray.nim
+++ b/ranges/stackarray.nim
@@ -1,0 +1,56 @@
+proc alloca(n: int): pointer {.importc, header: "<alloca.h>".}
+
+type
+  StackArray*[T] = ptr object
+    bufferLen: int
+    buffer: UncheckedArray[T]
+
+template `[]`*(a: StackArray, i: int): auto =
+  if i < 0 or i >= a.len: raise newException(RangeError, "index out of range")
+  a.buffer[i]
+
+proc `[]=`*(a: StackArray, i: int, val: a.T) =
+  if i < 0 or i >= a.len: raise newException(RangeError, "index out of range")
+  a.buffer[i] = val
+
+proc len*(a: StackArray): int {.inline.} =
+  a.bufferLen
+
+template high*(a: StackArray): int =
+  a.bufferLen - 1
+
+template low*(a: StackArray): int =
+  0
+
+iterator items*(a: StackArray): a.T =
+  for i in 0 .. a.high:
+    yield a.buffer[i]
+
+iterator mitems*(a: var StackArray): var a.T =
+  for i in 0 .. a.high:
+    yield a.buffer[i]
+
+iterator pairs*(a: StackArray): a.T =
+  for i in 0 .. a.high:
+    yield (i, a.buffer[i])
+
+iterator mpairs*(a: var StackArray): (int, var a.T) =
+  for i in 0 .. a.high:
+    yield (i, a.buffer[i])
+
+template allocStackArray*(T: typedesc, size: int): auto =
+  if size < 0: raise newException(RangeError, "allocation with a negative size")
+  # XXX: is it possible to perform a stack size check before
+  # calling `alloca`? Nim has a stackBottom pointer in the
+  # system module.
+  var
+    bufferSize = size * sizeof(T)
+    totalSize = sizeof(int) + bufferSize
+    arr = cast[StackArray[T]](alloca(totalSize))
+  zeroMem(addr arr.buffer[0], bufferSize)
+  arr.bufferLen = size
+  arr
+
+template toOpenArray*(a: StackArray): auto =
+  toOpenArray(a.buffer, 0, a.high)
+

--- a/ranges/stackarrays.nim
+++ b/ranges/stackarrays.nim
@@ -40,9 +40,10 @@ iterator mpairs*(a: var StackArray): (int, var a.T) =
 
 template allocStackArray*(T: typedesc, size: int): auto =
   if size < 0: raise newException(RangeError, "allocation with a negative size")
-  # XXX: is it possible to perform a stack size check before
-  # calling `alloca`? Nim has a stackBottom pointer in the
-  # system module.
+  # XXX: is it possible to perform a stack size check before calling `alloca`?
+  # On thread init, Nim may record the base address and the capacity of the stack,
+  # so in theory we can verify that we still have enough room for the allocation.
+  # Research this.
   var
     bufferSize = size * sizeof(T)
     totalSize = sizeof(int) + bufferSize

--- a/ranges/stackarrays.nim
+++ b/ranges/stackarrays.nim
@@ -17,6 +17,25 @@
 ##    Please note that the stack size on certain platforms
 ##    may be very small (e.g. 8 to 32 kb on some Android versions)
 ##
+## Before using alloca-backed arrays, consider using:
+##
+## 1. A regular stack array with a reasonable size
+##
+## 2. A global {.threadvar.} sequence that can be resized when
+##    needed (only in non-reentrant procs)
+##
+## Other possible future directions:
+##
+## Instead of `alloca`, we may start using a shadow stack that will be much
+## harder to overflow. This will work by allocating a very large chunk of the
+## address space at program init (e.g. 1TB on a 64-bit system) and then by
+## gradually committing the individual pages to memory as they are requested.
+##
+## Such a scheme will even allow us to resize the stack array on demand
+## in situations where the final size is not known upfront. With a resizing
+## factor of 2, we'll never waste more than 50% of the memory which should
+## be reasonable for short-lived allocations.
+##
 
 type
   StackArray*[T] = ptr object

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,1 +1,2 @@
-import ttypedranges
+import
+  ttypedranges, tstackarrays

--- a/tests/tstackarrays.nim
+++ b/tests/tstackarrays.nim
@@ -1,0 +1,34 @@
+import
+  unittest, math,
+  ../ranges/stackarray
+
+suite "Stack arrays":
+  test "Basic operations work as expected":
+    var arr = allocStackArray(int, 10)
+    check:
+      type(arr[0]) is int
+      arr.len == 10
+    
+    # all items should be initially zero
+    for i in arr: check i == 0
+    for i in 0 .. arr.high: check arr[i] == 0
+
+    arr[0] = 3
+    arr[5] = 10
+    arr[9] = 6
+
+    check:
+      sum(arr.toOpenArray) == 19
+      arr[5] == 10
+
+  test "Allocating with a negative size throws a RangeError":
+    expect RangeError:
+      var arr = allocStackArray(string, -1)
+
+  test "The array access is bounds-checked":
+    var arr = allocStackArray(string, 3)
+    arr[2] = "test"
+    check arr[2] == "test"
+    expect RangeError:
+      arr[3] = "another test"
+

--- a/tests/tstackarrays.nim
+++ b/tests/tstackarrays.nim
@@ -1,6 +1,6 @@
 import
   unittest, math,
-  ../ranges/stackarray
+  ../ranges/stackarrays
 
 suite "Stack arrays":
   test "Basic operations work as expected":
@@ -8,7 +8,7 @@ suite "Stack arrays":
     check:
       type(arr[0]) is int
       arr.len == 10
-    
+
     # all items should be initially zero
     for i in arr: check i == 0
     for i in 0 .. arr.high: check arr[i] == 0

--- a/tests/tstackarrays.nim
+++ b/tests/tstackarrays.nim
@@ -1,6 +1,6 @@
 import
   unittest, math,
-  ../ranges/stackarrays
+  ../ranges/[stackarrays, ptr_arith]
 
 suite "Stack arrays":
   test "Basic operations work as expected":
@@ -20,6 +20,8 @@ suite "Stack arrays":
     check:
       sum(arr.toOpenArray) == 19
       arr[5] == 10
+      arr[^1] == 6
+      cast[ptr int](shift(addr arr[0], 5))[] == 10
 
   test "Allocating with a negative size throws a RangeError":
     expect RangeError:


### PR DESCRIPTION
There is one open question:

```
  # XXX: is it possible to perform a stack size check before calling `alloca`?
  # On thread init, Nim may record the base address and the capacity of the stack,
  # so in theory we can verify that we still have enough room for the allocation.
  # Research this.
```
Some reference info:
https://stackoverflow.com/questions/46743669/why-does-alloca-not-check-if-it-can-allocate-memory