### PR TITLE
bugfix: allow the slice operators to return empty ranges

### DIFF
--- a/ranges/bitranges.nim
+++ b/ranges/bitranges.nim
@@ -137,8 +137,9 @@ proc `[]`*(x: BitRange, idx: int): bool {.inline.} =
 proc sliceNormalized(x: BitRange, ibegin, iend: int): BitRange =
   assert ibegin >= 0 and
          ibegin < x.len and
-         iend >= ibegin and
-         iend < x.len
+         iend < x.len and
+         iend + 1 >= ibegin # the +1 here allows the result to be
+                            # an empty range
 
   result.data  = x.data
   result.start = x.start + ibegin

--- a/ranges/typedranges.nim
+++ b/ranges/typedranges.nim
@@ -113,7 +113,12 @@ proc `$`*(r: Range): string =
   result &= "]"
 
 proc sliceNormalized[T](r: Range[T], ibegin, iend: int): Range[T] =
-  assert(ibegin >= 0 and ibegin < r.len and iend >= ibegin and iend < r.len)
+  assert ibegin >= 0 and
+         ibegin < r.len and
+         iend < r.len and
+         iend + 1 >= ibegin # the +1 here allows the result to be
+                            # an empty range
+
   when rangesGCHoldEnabled:
     result.gcHold = r.gcHold
   result.start = r.start.shift(ibegin)

--- a/tests/ttypedranges.nim
+++ b/tests/ttypedranges.nim
@@ -19,6 +19,9 @@ suite "Typed ranges":
     let b = toRange(@[1, 2, 3])
     a[1 .. 3] = b
     check a.toSeq == @[0, 1, 2, 3, 0]
+    check:
+      a[2 .. 2].len == 1
+      a[1 ..< 1].len == 0
 
   test "equality operator":
     var x = toRange(@[0, 1, 2, 3, 4, 5])
@@ -95,4 +98,4 @@ suite "Typed ranges":
     check hash(uu) == hash(u)
     check hash(v) == hash(vv)
     check hash(uu) != hash(vv)
-     
+


### PR DESCRIPTION
Empty ranges are produced sometimes from RLP functions such as `toBytes`.