### PR TITLE
allow skipping initialization in allocStackArray for O(1) typesafe alloca

### DIFF
--- a/ranges/stackarrays.nim
+++ b/ranges/stackarrays.nim
@@ -94,7 +94,9 @@ iterator mpairs*(a: var StackArray): (int, var a.T) =
   for i in 0 .. a.high:
     yield (i, a.buffer[i])
 
-template allocStackArray*(T: typedesc, size: int): auto =
+template allocStackArray*(T: typedesc, size: int, initialized = true): auto =
+  ## type-safe version of C's alloca intrinsic; ``initialized`` = false skips
+  ## initialization, resulting in O(1) stack allocation.
   let sz = int(size) # Evaluate size only once
   if sz < 0: raiseRangeError "allocation with a negative size"
   # XXX: is it possible to perform a stack size check before calling `alloca`?
@@ -105,7 +107,8 @@ template allocStackArray*(T: typedesc, size: int): auto =
     bufferSize = sz * sizeof(T)
     totalSize = sizeof(int32) + bufferSize
     arr = cast[StackArray[T]](alloca(totalSize))
-  zeroMem(addr arr.buffer[0], bufferSize)
+  if initialized:
+    zeroMem(addr arr.buffer[0], bufferSize)
   arr.bufferLen = int32(sz)
   arr
 

--- a/tests/tstackarrays.nim
+++ b/tests/tstackarrays.nim
@@ -34,3 +34,27 @@ suite "Stack arrays":
     expect RangeError:
       arr[3] = "another test"
 
+  test "proof of stack allocation":
+    proc fun() =
+      # NOTE: has to be inside a proc otherwise x1 not allocated on stack.
+      var x1 = 0
+      var arr = allocStackArray(int, 3)
+      var x2 = 0
+      let p_addr = cast[int](addr arr)
+      let p_x1 = cast[int](addr x1)
+      let p_x2 = cast[int](addr x2)
+      check:
+        # stack can go either up or down
+        p_addr > min(p_x1, p_x2) and p_addr < max(p_x1, p_x2)
+    fun()
+
+  test "skip initialization":
+    proc fun():auto =
+      let n = 3
+      var arr = allocStackArray(int, n, initialized = false)
+      check arr.len == n
+      # should contain random garbage from stack
+      return $(arr.toOpenArray)
+    let a0=fun()
+    let a1=fun()
+    check a0 == a1


### PR DESCRIPTION
* allow skipping initialization in allocStackArray for O(1) typesafe alloca #17
* add test "proof of stack allocation"