### PR TITLE
test toOpenArray and clarify doc to say 0 in cast[ptr array[0, T] is irrelevant

### DIFF
--- a/ranges/typedranges.nim
+++ b/ranges/typedranges.nim
@@ -153,7 +153,8 @@ proc `[]=`*[T, U, V](r: MutRange[T], s: HSlice[U, V], v: openarray[T]) =
 template toOpenArray*[T](r: Range[T]): auto =
   # TODO: Casting through an {.unchecked.} array would be more appropriate
   # here, but currently this results in internal compiler error.
-  toOpenArray(cast[ptr array[10000000, T]](r.start)[], 0, r.high)
+  # NOTE: `0` in `array[0, T]` is irrelevant
+  toOpenArray(cast[ptr array[0, T]](r.start)[], 0, r.high)
 
 proc `[]=`*[T, U, V](r: MutRange[T], s: HSlice[U, V], v: Range[T]) {.inline.} =
   r[s] = toOpenArray(v)

--- a/tests/ttypedranges.nim
+++ b/tests/ttypedranges.nim
@@ -99,3 +99,6 @@ suite "Typed ranges":
     check hash(v) == hash(vv)
     check hash(uu) != hash(vv)
 
+  test "toOpenArray":
+    var a = toRange(@[1,2,3])
+    check $a.toOpenArray == "[1, 2, 3]"


### PR DESCRIPTION
as @yglukhov said in https://github.com/nim-lang/Nim/issues/5437#issuecomment-403717485, 
> compile time size is ignored

so I put `0` instead of `10000000` along with a clarification in comment; also added a test for toOpenArray